### PR TITLE
Hook up databroker into the re-manager

### DIFF
--- a/bluesky-queueserver/dockerfile
+++ b/bluesky-queueserver/dockerfile
@@ -1,7 +1,8 @@
 FROM debian:bullseye
 RUN apt update
+RUN apt install git -y
 RUN apt install librdkafka-dev -y
 RUN apt install python3-pip -y
-RUN python3 -m pip install bluesky-queueserver
+RUN python3 -m pip install git+https://github.com/bluesky/bluesky-queueserver@main
 RUN python3 -c "import distutils.spawn; print(distutils.spawn.find_executable('uvicorn'))"
 CMD ["uvicorn", "bluesky_queueserver.server.server:app", "--port", "60610"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: "3.7"
 services:
   mongo:
     image: mongo:latest

--- a/re-manager/databroker-config.yml
+++ b/re-manager/databroker-config.yml
@@ -1,0 +1,7 @@
+# ~/.local/share/intake/catalog.yml
+sources:
+  mongo:
+    driver: bluesky-mongo-normalized-catalog
+    args:
+      metadatastore_db: mongodb://localhost:27017/metadatastore
+      asset_registry_db: mongodb://localhost:27017/asset_registry

--- a/re-manager/dockerfile
+++ b/re-manager/dockerfile
@@ -1,7 +1,9 @@
 FROM debian:bullseye
 RUN apt update
+RUN apt install git -y
 RUN apt install librdkafka-dev -y
 RUN apt install python3-pip -y
-RUN python3 -m pip install bluesky-queueserver
+COPY ./databroker-config.yml /usr/local/share/intake/catalog.yml
+RUN python3 -m pip install git+https://github.com/bluesky/bluesky-queueserver@main
 RUN python3 -c "import distutils.spawn; print(distutils.spawn.find_executable('start-re-manager'))"
-CMD ["/usr/local/bin/start-re-manager"]
+CMD ["/usr/local/bin/start-re-manager", "--databroker-config=mongo"]


### PR DESCRIPTION
This also uses the git version of queueserver as the last release is out of date for the databroker-config option (updated both so that they stay in sync, though it actually worked more or less fine with the version mismatch.

If we wanted to be safe, we could pin to a hash instead of the main branch, but for now my opinion is that this is experimental and we intend to keep up with upstream. 