### PR TITLE
Update as needed for queueserver 0.0.10, namely : in user_group_permi…

### DIFF
--- a/hwproxy/dockerfile
+++ b/hwproxy/dockerfile
@@ -10,7 +10,7 @@ RUN python3 -m pip install wright-plans attune
 
 # happi
 RUN python3 -m pip install happi
-RUN python3 -m pip install git+https://github.com/bluesky/yaqc-bluesky
+RUN python3 -m pip install git+https://github.com/ksunden/yaqc-bluesky@426dfced
 COPY ./happi.ini /happi.ini
 ENV HAPPI_CFG /happi.ini
 

--- a/re-manager/dockerfile
+++ b/re-manager/dockerfile
@@ -15,12 +15,12 @@ COPY ./databroker-config.yml /usr/local/share/intake/catalog.yml
 
 # happi
 RUN python3 -m pip install happi
-RUN python3 -m pip install git+https://github.com/bluesky/yaqc-bluesky
+RUN python3 -m pip install git+https://github.com/ksunden/yaqc-bluesky@426dfce
 COPY ./happi.ini /happi.ini
 ENV HAPPI_CFG /happi.ini
 
 # re-manager
-RUN python3 -m pip install git+https://github.com/bluesky/bluesky-queueserver
+RUN python3 -m pip install bluesky-queueserver
 RUN python3 -m pip install git+https://github.com/wright-group/wright-plans
 COPY ./startup.py ./startup.py
 COPY ./start_re.sh ./start_re.sh

--- a/re-manager/user_group_permissions.yaml
+++ b/re-manager/user_group_permissions.yaml
@@ -14,6 +14,6 @@ user_groups:
     forbidden_plans:
       - null  # Nothing is forbidden
     allowed_devices:
-      - ":.*"  # A different way to allow all
+      - ":.*:?.*"  # A different way to allow all
     forbidden_devices:
       - null  # Nothing is forbidden

--- a/re-manager/user_group_permissions.yaml
+++ b/re-manager/user_group_permissions.yaml
@@ -3,17 +3,17 @@ user_groups:
     allowed_plans:
       - null  # Allow all
     forbidden_plans:
-      - "^_"  # All plans with names starting with '_'
+      - ":^_"  # All plans with names starting with '_'
     allowed_devices:
       - null  # Allow all
     forbidden_devices:
-      - "^_"  # All devices with names starting with '_'
+      - ":^_"  # All devices with names starting with '_'
   admin:  # The group includes beamline staff, includes all or most of the plans and devices
     allowed_plans:
-      - ".*"  # A different way to allow all
+      - ":.*"  # A different way to allow all
     forbidden_plans:
       - null  # Nothing is forbidden
     allowed_devices:
-      - ".*"  # A different way to allow all
+      - ":.*"  # A different way to allow all
     forbidden_devices:
       - null  # Nothing is forbidden


### PR DESCRIPTION
Namely `:` in user_group_permissions, pinning some workaround versions of deps

I think we should investigate using only released versions  (though in active dev that is a little hard...) and using something like dependabot to auto update for us strictly pinned versions, preferably with a test suite in place.

Things are starting to get to the point where hopefully interconnected problems slow (though there were a few, still)