### PR TITLE
Only store simple constants

### DIFF
--- a/wt5/wt5_event_model.py
+++ b/wt5/wt5_event_model.py
@@ -143,15 +143,8 @@ class GenWT5(CallbackBase):
 
         if stream_name == "primary":
             for hw, (units, terms) in self.start_doc.get("plan_constants", {}).items():
-                terms.append([-1, hw])
-                const_term = -1 * ([t for t in terms if t[1] is None] or [[0]])[0][0]
-                terms = list(filter(lambda x: x[1] is not None, terms))
-                if const_term < 0:
-                    terms = [[-1 * coeff, var] for coeff, var in terms]
-                c = self.data[stream_name].create_constant(
-                    "+".join(f"{coeff}*{var}" for coeff, var in terms)
-                )
-                c.units = units
+                if len(terms) == 1 and terms[0][1] is None:
+                    c = self.data[stream_name].create_constant(terms[0][0], units=units)
 
         # Add stationary hardware to the primary dataset
         # This assumes the order is baseline descriptor -> baseline reading -> primary descriptor


### PR DESCRIPTION
closes #28

This is a bit of a "one fell swoop" fix

I'm still not sure why print tree was failing in the first place,
however I could nail it to "constants that reference motors that are not
in the axes or other constants"

I was also considering this change before I realized it solved this
particular issue because the constants produced from expressions are
often obtuse and make the autogenerated plots that much harder to parse.
(And are often supposed to be 0 since d1=d2 gets translated as d1-d2=0)

When I realized it would fix #28, I just decided to go with it.

The "simple" constant of "variable = #" is retained, as those are not
obtuse and can be genuinely helpful and have the same meaning between
scan constant and data constant.
