### PR TITLE
Update requirements

### DIFF
--- a/bluesky-queueserver/dockerfile
+++ b/bluesky-queueserver/dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:trixie
 RUN apt update
 RUN apt install git -y
 RUN apt install librdkafka-dev -y

--- a/hwproxy/dockerfile
+++ b/hwproxy/dockerfile
@@ -1,14 +1,22 @@
-FROM debian:bullseye
+FROM debian:bookworm
 
 # python
 RUN apt update
 RUN apt install git -y
 RUN apt install librdkafka-dev -y
 RUN apt install python3-pip -y
+RUN apt install python3-venv -y
 
 # happi
 COPY ./happi.ini /happi.ini
 COPY ./requirements.txt ./
+
+# Create a virtual environment
+RUN python3 -m venv /opt/venv
+
+# Activate the virtual environment
+ENV PATH="/opt/venv/bin:$PATH"
+
 RUN pip install -r requirements.txt
 
 ENV HAPPI_CFG /happi.ini

--- a/hwproxy/dockerfile
+++ b/hwproxy/dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm
+FROM debian:trixie
 
 # python
 RUN apt update

--- a/hwproxy/requirements.txt
+++ b/hwproxy/requirements.txt
@@ -1,9 +1,9 @@
-bluesky==1.10.0
-pint==0.19.2
-numpy==1.26.4
-attune==0.4.4
-happi==1.14.0
-yaqc-bluesky==2022.4.1
 bluesky-queueserver==0.0.16
-wright-plans==2022.7.0
 bluesky-hwproxy==2022.8.0
+bluesky==1.10.0
+pint==0.24.4
+numpy<2.0
+happi<3.0
+attune
+yaqc-bluesky
+wright-plans

--- a/hwproxy/requirements.txt
+++ b/hwproxy/requirements.txt
@@ -1,9 +1,9 @@
-bluesky==1.10.0
-pint
-numpy
-attune
-happi
-yaqc-bluesky
-bluesky-queueserver
-wright-plans
-bluesky-hwproxy
+attune==0.5.1
+bluesky==1.10.0  # ignore
+bluesky-hwproxy==2022.8.0
+bluesky-queueserver==0.0.24
+happi==3.0.1
+numpy==2.4.4
+pint==0.25.3
+wright-plans==2022.7.0
+yaqc-bluesky==2023.8.0

--- a/hwproxy/requirements.txt
+++ b/hwproxy/requirements.txt
@@ -1,9 +1,9 @@
 bluesky==1.10.0
-pint==0.19.2
-numpy==1.26.4
-attune==0.4.4
-happi==1.14.0
-yaqc-bluesky==2022.4.1
-bluesky-queueserver==0.0.16
-wright-plans==2022.7.0
-bluesky-hwproxy==2022.8.0
+pint
+numpy
+attune
+happi
+yaqc-bluesky
+bluesky-queueserver
+wright-plans
+bluesky-hwproxy

--- a/re-manager/dockerfile
+++ b/re-manager/dockerfile
@@ -1,10 +1,11 @@
-FROM debian:bullseye
+FROM debian:bookworm
 
 # python
 RUN apt update
 RUN apt install git -y
 RUN apt install librdkafka-dev -y
 RUN apt install python3-pip -y
+RUN apt install python3-venv -y
 
 COPY ./databroker-config.yml /usr/local/share/intake/catalog.yml
 COPY ./happi.ini /happi.ini
@@ -13,6 +14,13 @@ COPY ./start_re.sh ./start_re.sh
 COPY ./user_group_permissions.yaml ./user_group_permissions.yaml
 COPY ./requirements.txt /requirements.txt
 
+# Create a virtual environment
+RUN python3 -m venv /opt/venv
+
+# Activate the virtual environment
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Install dependencies
 RUN python3 -m pip install -r requirements.txt
 
 ENV PYTHONUNBUFFERED 1

--- a/re-manager/requirements.txt
+++ b/re-manager/requirements.txt
@@ -1,8 +1,8 @@
-attune
-bluesky==1.10.0
-bluesky-queueserver==0.0.20
-happi
-numpy
-pint
-wright-plans
-yaqc-bluesky
+attune==0.5.1
+bluesky==1.10.0  # ignore
+bluesky-queueserver==0.0.20  # ignore
+happi==3.0.1
+numpy < 2.4  # ignore
+pint==0.25.3
+wright-plans==2022.7.0
+yaqc-bluesky==2023.8.0

--- a/re-manager/requirements.txt
+++ b/re-manager/requirements.txt
@@ -1,8 +1,8 @@
-bluesky==1.10.0
-pint==0.24.4
-numpy<2.0
-attune==0.5.1
-happi<3.0
-yaqc-bluesky
+attune
 bluesky-queueserver==0.0.16
+bluesky==1.10.0
+happi<3.0
+numpy<2.0
+pint==0.24.4
 wright-plans
+yaqc-bluesky

--- a/re-manager/requirements.txt
+++ b/re-manager/requirements.txt
@@ -1,8 +1,8 @@
 bluesky==1.10.0
-pint==0.19.2
-numpy==1.26.4
-attune==0.4.4
-happi==1.14.0
-yaqc-bluesky==2022.4.1
+pint==0.24.4
+numpy<2.0
+attune==0.5.1
+happi<3.0
+yaqc-bluesky
 bluesky-queueserver==0.0.16
-wright-plans==2022.7.0
+wright-plans

--- a/re-manager/requirements.txt
+++ b/re-manager/requirements.txt
@@ -1,8 +1,8 @@
+attune
 bluesky==1.10.0
-pint==0.19.2
-numpy==1.26.4
-attune==0.4.4
-happi==1.14.0
-yaqc-bluesky==2022.4.1
-bluesky-queueserver==0.0.16
-wright-plans==2022.7.0
+bluesky-queueserver==0.0.20
+happi
+numpy
+pint
+wright-plans
+yaqc-bluesky

--- a/re-manager/start_re.sh
+++ b/re-manager/start_re.sh
@@ -1,5 +1,4 @@
 #! /bin/sh
 
 qserver-list-plans-devices --startup-script startup.py
-/usr/local/bin/start-re-manager --databroker-config=mongo --startup-script=./startup.py --existing-plans-devices=./existing_plans_and_devices.yaml --user-group-permissions=./user_group_permissions.yaml --zmq-data-proxy-addr zmq-proxy:5567 --redis-addr redis:6379 --zmq-publish-console ON
-
+start-re-manager --databroker-config=mongo --startup-script=./startup.py --existing-plans-devices=./existing_plans_and_devices.yaml --user-group-permissions=./user_group_permissions.yaml --zmq-data-proxy-addr zmq-proxy:5567 --redis-addr redis:6379 --zmq-publish-console ON

--- a/slack/dockerfile
+++ b/slack/dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-bullseye
+FROM python:3.12-trixie
 COPY ./requirements.txt ./
 RUN python3 -m pip install -r requirements.txt
 COPY ./slack_bot.py ./

--- a/slack/requirements.txt
+++ b/slack/requirements.txt
@@ -1,5 +1,5 @@
 bluesky==1.10.0
-pyzmq==23.2.0
+pyzmq==27.0.2
 slack_sdk
 slack_bolt
 aiohttp

--- a/slack/requirements.txt
+++ b/slack/requirements.txt
@@ -1,5 +1,5 @@
 bluesky==1.10.0
-pyzmq==23.2.0
+pyzmq
 slack_sdk
 slack_bolt
 aiohttp

--- a/slack/requirements.txt
+++ b/slack/requirements.txt
@@ -1,5 +1,5 @@
 bluesky==1.10.0
-pyzmq
-slack_sdk
-slack_bolt
-aiohttp
+pyzmq==27.1.0
+slack_sdk==3.41.0
+slack_bolt==1.28.0
+aiohttp==3.13.5

--- a/wt5/dockerfile
+++ b/wt5/dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-bullseye
+FROM python:3.12-trixie
 COPY ./requirements.txt ./
 RUN python3 -m pip install -r requirements.txt
 COPY ./wt5_event_model.py ./

--- a/wt5/requirements.txt
+++ b/wt5/requirements.txt
@@ -1,5 +1,5 @@
-bluesky==1.10.0
-WrightTools
-pyzmq
-numpy
-toolz
+bluesky==1.10.0  # ignore
+numpy==2.4.4
+pyzmq==27.1.0
+toolz==1.1.0
+WrightTools==3.6.3

--- a/wt5/requirements.txt
+++ b/wt5/requirements.txt
@@ -1,5 +1,5 @@
 bluesky==1.10.0
-WrightTools==3.4.6
-pyzmq==23.2.0
-numpy==1.23.1
-toolz==0.12.0
+WrightTools
+pyzmq==27.0.2
+numpy<2.0
+toolz==1.0.0

--- a/wt5/requirements.txt
+++ b/wt5/requirements.txt
@@ -1,5 +1,5 @@
 bluesky==1.10.0
-WrightTools==3.4.6
-pyzmq==23.2.0
-numpy==1.23.1
-toolz==0.12.0
+WrightTools
+pyzmq
+numpy
+toolz

--- a/zmq-proxy/dockerfile
+++ b/zmq-proxy/dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-bullseye
+FROM python:3.12-trixie
 COPY ./requirements.txt ./
 RUN python3 -m pip install -r requirements.txt
 CMD ["bluesky-0MQ-proxy", "5567", "5568"]

--- a/zmq-proxy/requirements.txt
+++ b/zmq-proxy/requirements.txt
@@ -1,2 +1,2 @@
 bluesky==1.10.0
-pyzmq==23.2.0
+pyzmq

--- a/zmq-proxy/requirements.txt
+++ b/zmq-proxy/requirements.txt
@@ -1,2 +1,2 @@
-bluesky==1.10.0
-pyzmq
+bluesky==1.10.0  # ignore
+pyzmq==27.1.0

--- a/zmq-proxy/requirements.txt
+++ b/zmq-proxy/requirements.txt
@@ -1,2 +1,2 @@
 bluesky==1.10.0
-pyzmq==23.2.0
+pyzmq==27.0.2


### PR DESCRIPTION
Due for an update (3 years since we checked the pins).  notes:
* several dependencies can be updated to current versions (numpy, happi, WrightTools, attune)
* `bluesky-queueserver` is pinned lower than latest because kwargs change in an updated version--haven't accounted for those yet
* updating debian: needed to implement venvs for installing requirements
* `re-manager` needs python-3.11 still because we use databroker v1; a bypass option is to disable mongo, but it also looks like updating to latest bluesky-queueserver (v0.0.22) will also resolve the issue.
* keeping packages that we have some control over as unpinned (attune, WrightTools, wright-plans, etc), since we likely want our package to update as we update those.
* ~note that our queueserver container always pulls the latest version, but we pin lower versions in other containers that use the package~ (bluesky-queueserver build it not used anymore and queueserver is implemented in re-manager)

at some point we will want to update bluesky, but not today.

## TODO
- [x] test on guinea_pig system
- [x] test on fs-system
- [x] repin dependencies

