### PR TITLE
resave wt5s

### DIFF
--- a/wt5/wt5_event_model.py
+++ b/wt5/wt5_event_model.py
@@ -3,6 +3,7 @@ import json
 import pathlib
 import subprocess
 import traceback
+import logging
 
 from bluesky.callbacks.zmq import RemoteDispatcher
 from bluesky.callbacks import CallbackBase
@@ -227,6 +228,8 @@ class GenWT5(CallbackBase):
             self.data[name].flush()
             self.data[name].close()
 
+            resave(filepath)
+
             for dev, hints in descriptor_doc["hints"].items():
                 for chan in hints["fields"]:
                     try:
@@ -268,6 +271,25 @@ def add_inner_list_product_axes(data, pattern_args, motors, axis_units):
         arr = np.array(lis)
         arr = arr.reshape(tuple(shape))
         data.create_variable(f"{mot}_points", values=arr, units=axis_units.get(mot), compression="gzip", shuffle=True)
+
+def resave(filepath):
+    try:
+        first = pathlib.Path(filepath)
+        first_size = first.stat.st_size
+        data = wt.open(first)
+        data.save(first, overwrite=True)
+        second_size = first.stat.st_size
+
+        logging.getLogger().info(f"second save: {get_human_size(first_size)} -> {get_human_size(second_size)}")
+    except Exception as e:
+        traceback.print_exc()
+        print(f"Failed to resave {str(filepath)}")
+
+def get_human_size(size_bytes):
+    for unit in ['B', 'KB', 'MB', 'GB']:
+        if size_bytes < 1024:
+            return f"{size_bytes:.2f} {unit}"
+        size_bytes /= 1024
 
 
 dispatcher = RemoteDispatcher("zmq-proxy:5568")

--- a/wt5/wt5_event_model.py
+++ b/wt5/wt5_event_model.py
@@ -11,6 +11,10 @@ import numpy as np
 import toolz
 import WrightTools as wt
 
+
+logging.basicConfig(level=logging.INFO)
+
+
 class NumpyArrayEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, np.ndarray):
@@ -275,10 +279,10 @@ def add_inner_list_product_axes(data, pattern_args, motors, axis_units):
 def resave(filepath):
     try:
         first = pathlib.Path(filepath)
-        first_size = first.stat.st_size
+        first_size = first.stat().st_size
         data = wt.open(first)
         data.save(first, overwrite=True)
-        second_size = first.stat.st_size
+        second_size = first.stat().st_size
 
         logging.getLogger().info(f"second save: {get_human_size(first_size)} -> {get_human_size(second_size)}")
     except Exception as e:


### PR DESCRIPTION
We've known for years that our write from stream can produce filesizes much larger than the containing data suggests.   In particular, data with higher dimensionality scans (where the detector is not part of the dimensionality) can take up 100x more space than it should.

This can probably be fixed by changing something about our dispatch writer, but this PR instead achieves the same effect by resaving the dataset after the scan has completed (something we have done manually for years for datasets we care about).

## resave effects from this PR on waldo:
- 41x41 2D frequency scan (uid `47829e47`): 14.2 MB -> 663 kB (20x more compact)
- 13x41x41 3D scan (uid `75b7941c`): 185 MB -> 2.7 MB (68x more compact)